### PR TITLE
Support for error handling and promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-data",
-  "version": "0.1.0",
-  "description": "Generate a data object from a variety of sources: json, front-matter, database, anything... and set it to the file object for other plugins to consume.",
+  "version": "1.0.1",
+  "description": "Generate a data object from a variety of sources: json, front-matter, databases, promises, anything... and set it to the file object for other plugins to consume.",
   "keywords": [
     "gulpplugin", "data", "json", "gulp"
   ],
@@ -10,6 +10,11 @@
     "email": "colyn.brown@gmail.com",
     "url": "https://github.com/colynb"
   },
+  "contributors": [{
+    "name": "Izaak Schroeder",
+    "email": "izaak.schroeder@gmail.com",
+    "url": "http://www.github.com/izaakschroeder"
+  }],
   "repository": "colynb/gulp-data",
   "scripts": {
     "test": "istanbul test _mocha --report html -- test/*.js --reporter spec"

--- a/test/main.js
+++ b/test/main.js
@@ -19,6 +19,58 @@ describe("gulp-data", function() {
     message: 'Hello'
   };
 
+  it("should handle exceptions with the callback present", function(done) {
+    var srcFile = new gutil.File({
+      path: "test/fixtures/hello.txt",
+      cwd: "test/",
+      base: "test/fixtures",
+      contents: fs.readFileSync("test/fixtures/hello.txt")
+    });
+
+    var stream = data(function(file, cb) {
+      throw new Error('potato');
+    });
+
+    stream.on("error", function(err) {
+      should.exist(err);
+      should.exist(err.stack);
+      done();
+    });
+
+    stream.on("end", function() {
+      done('fail');
+    })
+
+    stream.write(srcFile);
+    stream.end();
+  })
+
+  it("should handle exceptions without the callback present", function(done) {
+    var srcFile = new gutil.File({
+      path: "test/fixtures/hello.txt",
+      cwd: "test/",
+      base: "test/fixtures",
+      contents: fs.readFileSync("test/fixtures/hello.txt")
+    });
+
+    var stream = data(function(file) {
+      throw new Error('potato');
+    });
+
+    stream.on("error", function(err) {
+      should.exist(err);
+      should.exist(err.stack);
+      done();
+    });
+
+    stream.on("end", function() {
+      done('fail');
+    })
+
+    stream.write(srcFile);
+    stream.end();
+  })
+
   it("should produce errors when data handler has error", function(done) {
     var srcFile = new gutil.File({
       path: "test/fixtures/hello.txt",
@@ -79,6 +131,35 @@ describe("gulp-data", function() {
 
   });
 
+  it("should work with returned values", function(done) {
+    var srcFile = new gutil.File({
+      path: "test/fixtures/hello.txt",
+      cwd: "test/",
+      base: "test/fixtures",
+      contents: fs.readFileSync("test/fixtures/hello.txt")
+    });
+
+    var stream = data(function() {
+      return { message: 'Hello' }
+    });
+
+
+    stream.on("error", function(err) {
+      should.exist(err);
+      done(err);
+    });
+
+    stream.on("data", function(newFile) {
+      should.exist(newFile);
+      should.exist(newFile.data);
+      newFile.data.should.have.property('message', 'Hello');
+      done();
+    });
+
+    stream.write(srcFile);
+    stream.end();
+  });
+
   it("should work with promises that resolve", function(done) {
     var srcFile = new gutil.File({
       path: "test/fixtures/hello.txt",
@@ -125,7 +206,7 @@ describe("gulp-data", function() {
       return deferred.promise;
     });
 
-    
+
 
     stream.on("error", function(err) {
       should.exist(err);


### PR DESCRIPTION
Now you can have error handling in your callbacks (more in-line with standard node callbacks); you can also use promises in the same fashion gulp does which makes some patterns simpler. Appropriate tests have been added. Unfortunately this breaks previous data providers, but data consumers are not effected. Some examples of the new style follow.

Generate an error:

``` javascript
data(function(cb) { cb('error') });
```

Return a successful result:

``` javascript
data(function(cb) { cb(undefined, { hello: 'World' }) });
```

Use a promise from MongoDB:

``` javascript
data(collection.findOne({ tag: 'test' }))
```

Use a promise from MongoDB within the callback:

``` javascript
data(function(file) { 
    return collection.find({ filename: path.basename(file.path) }); 
})
```
