### PR TITLE
make it posible to skip files

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,10 @@ module.exports = function(data) {
         self.emit('error', new gutil.PluginError('gulp-data', { message: err }));
         return callback();
       }
-      file.data = extend(file.data || {}, result);
-      self.push(file);
+      if (result !== null) {
+        file.data = extend(file.data || {}, result);
+        self.push(file);
+      }
       callback();
     }
 

--- a/package.json
+++ b/package.json
@@ -29,19 +29,19 @@
     "test": "istanbul test _mocha --report html -- test/*.js"
   },
   "dependencies": {
-    "gulp-util": "^3.0.2",
-    "through2": "^1.1.1",
+    "gulp-util": "^3.0.6",
+    "through2": "^2.0.0",
     "util-extend": "^1.0.1"
   },
   "devDependencies": {
     "coveralls": "*",
     "istanbul": "*",
-    "jshint": "^2.6.0",
+    "jshint": "^2.8.0",
     "mocha": "*",
     "mocha-lcov-reporter": "*",
-    "q": "^1.0.1",
-    "should": "^4.6.1",
-    "vinyl": "^0.4.6"
+    "q": "^1.4.1",
+    "should": "^7.1.0",
+    "vinyl": "^0.5.3"
   },
   "engines": {
     "node": ">=0.9.0",


### PR DESCRIPTION
Hi there,
if using the callback (async) handler it is impossible to skip files (like mentioned in issue #13 with sync)..
Like this 
```
gulp.task('json-test', function() {
  return gulp.src('./examples/test1.html')
    .pipe(data(function(file, cb) {
      some_async_stuff(function() { cb(undefined, null); });
    }))
    .pipe(swig())
    .pipe(gulp.dest('build'));
});
```
I changed only that it checks what kind of return it gets, and if ```null``` it skips it.